### PR TITLE
Corner case with netbeans ant patch-for-maven

### DIFF
--- a/src/main/java/org/codehaus/mojo/nbm/repository/PopulateRepositoryMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/repository/PopulateRepositoryMojo.java
@@ -809,8 +809,22 @@ public class PopulateRepositoryMojo
                         }
                         catch ( AbstractArtifactResolutionException x2 )
                         {
-                            getLog().warn( x2.getOriginalMessage() );
-                            throw new MojoExecutionException( "No module found for dependency '" + elem + "'", x );
+                            try
+                            {
+                                artifactResolver.resolve( artifactFactory.createBuildArtifact( groupIdPrefix + GROUP_EXTERNAL, artifactId, forcedVersion, "pom" ), repos, localRepository );
+                                dep.setGroupId( groupIdPrefix + GROUP_EXTERNAL );
+                                if ( wrapper.getModuleManifest().hasPublicPackages() )
+                                {
+                                    dep.setScope( "runtime" );
+                                }
+                            }
+                            catch ( AbstractArtifactResolutionException x3 )
+                            {
+                                getLog().warn( x3.getOriginalMessage() );
+                                throw new MojoExecutionException( "No module found for dependency '" + elem + "'", x );
+                            }
+
+                           
                         }
 
                     }


### PR DESCRIPTION
I try to use and enhance ([1])the ant patch-for-maven in the netbeans source and it works most of the case but on some modules it fails because some artefact are assumed to be in org.netbeans.api or org.netbeans.module group but are in fact in org.netbeans.external

A basic case is for example:
 api.htmlui
 ant patch-for-maven
 the populate goal scans for net-java-html but fail to find it on api or modules as its on external.

 The PR is a workaround but I cannot figure out if it breaks the plugin workflow or if the root cause is elsewhere.

[1]https://netbeans.org/bugzilla/show_bug.cgi?id=251841
