### PR TITLE
make nb-repository-plugin download runnable on  maven 3.5+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/nbactions.xml

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
                         <configuration>
                             <signature>
                                 <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java16</artifactId>
+                                <artifactId>java17</artifactId>
                                 <version>1.0</version>
                             </signature>
                         </configuration>
@@ -366,7 +366,7 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>3.6.2</version>
+            <version>5.5.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -400,7 +400,7 @@
         <dependency>
             <groupId>org.apache.maven.indexer</groupId>
             <artifactId>indexer-core</artifactId>
-            <version>5.1.1</version>
+            <version>6.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
    <!-- TODO need to override parent version value... I suppose this will eventually end up in mojo parent pom, check regularly -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.5</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                  </configuration>
@@ -383,23 +383,23 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.0.5</version>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.0.5</version>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.1</version>
+            <version>3.5</version>
             <scope>compile</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -414,23 +414,23 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.0.5</version>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.0.5</version>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>2.1</version>
+            <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>3.0.4</version>
+            <version>3.5.2</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -465,7 +465,7 @@
         <dependency>
             <groupId>org.sonatype.sisu</groupId>
             <artifactId>sisu-inject-plexus</artifactId>
-            <version>2.3.0</version>
+            <version>2.6.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,50 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>run-its</id>
+            <build>
 
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>2.0.0</version>
+                        <configuration>
+                            <debug>true</debug>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <goals>
+                                <!-- default build in netbeans IDE -->
+                                <goal>clean</goal>
+                                <goal>install</goal>
+                            </goals>
+                            <filterProperties>
+                                <netbeans.version>RELEASE82</netbeans.version> 
+                            </filterProperties>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+
+            </build>
+        </profile>
+    </profiles>
     <!--profiles>
         <profile>
             <id>tools.jar</id>

--- a/pom.xml
+++ b/pom.xml
@@ -383,12 +383,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.5.2</version>
+            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.5.2</version>
+            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -414,12 +414,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.5.2</version>
+            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.5.2</version>
+            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
@@ -430,7 +430,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>3.5.2</version>
+            <version>${maven.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -466,5 +466,6 @@
     <properties>
         <mojo.java.target>1.6</mojo.java.target>
         <wagon.version>3.0.0</wagon.version>
+        <maven.version>3.1.1</maven.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <url>https://github.com/mojohaus/nb-repository-plugin/issues</url>
     </issueManagement>
     <prerequisites>
-        <maven>3.0.5</maven>
+        <maven>3.1.1</maven>
     </prerequisites>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
                         <artifactId>maven-invoker-plugin</artifactId>
                         <version>2.0.0</version>
                         <configuration>
-                            <debug>true</debug>
+                            <debug>false</debug>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <pomIncludes>
                                 <pomInclude>*/pom.xml</pomInclude>
@@ -409,7 +409,7 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>5.5.4</version>
+            <version>5.5.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -443,7 +443,7 @@
         <dependency>
             <groupId>org.apache.maven.indexer</groupId>
             <artifactId>indexer-core</artifactId>
-            <version>6.0-SNAPSHOT</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
@@ -462,15 +462,9 @@
             <version>${wagon.version}</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.sonatype.sisu</groupId>
-            <artifactId>sisu-inject-plexus</artifactId>
-            <version>2.6.0</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
     <properties>
         <mojo.java.target>1.6</mojo.java.target>
-        <wagon.version>2.9</wagon.version>
+        <wagon.version>3.0.0</wagon.version>
     </properties>
 </project>

--- a/src/it/folder/pom.xml
+++ b/src/it/folder/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>nb-repository-plugin-it-root</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>nb-repository-plugin-it-single-module</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>nb-repository-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>download</goal>
+                        </goals>
+                        <configuration>
+                            <nexusIndexDirectory>${project.build.directory}/indextest</nexusIndexDirectory>
+                            <repositoryUrl>http://repo1.maven.org/maven2</repositoryUrl>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/pom.xml
+++ b/src/it/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>nb-repository-plugin-it-root</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+  
+    <build>
+        <pluginManagement>
+            <plugins>
+               
+                <plugin>  
+                    <groupId>@project.groupId@</groupId>
+                    <artifactId>@project.artifactId@</artifactId>  
+                    <version>@project.version@</version>
+                </plugin>
+                <!--<plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>@compilerPluginVersion@</version>
+                    <configuration>
+                        <source>@testJavaVersion@</source>
+                        <target>@testJavaVersion@</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>@surefirePluginVersion@</version>
+                </plugin>-->
+            </plugins>
+        </pluginManagement>
+    </build>
+    <properties>
+        <jar.plugin.version>3.0.2</jar.plugin.version>
+    </properties>
+</project>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/src/main/java/org/codehaus/mojo/nbm/repository/PopulateRepositoryMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/repository/PopulateRepositoryMojo.java
@@ -41,8 +41,9 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Fieldable;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreDoc;
@@ -287,8 +288,8 @@ public class PopulateRepositoryMojo
         {
             try
             {
-                Directory nexusDir = FSDirectory.open( nexusIndexDirectory );
-                IndexReader nexusReader = IndexReader.open( nexusDir );
+                Directory nexusDir = FSDirectory.open( nexusIndexDirectory.toPath() );
+                IndexReader nexusReader = DirectoryReader.open( nexusDir );
                 searcher = new IndexSearcher( nexusReader );
                 getLog().info( "Opened index with " + nexusReader.numDocs() + " documents" );
             }
@@ -620,7 +621,7 @@ public class PopulateRepositoryMojo
         }
         finally
         {
-            if ( searcher != null )
+            /*if ( searcher != null )
             {
                 try
                 {
@@ -630,7 +631,7 @@ public class PopulateRepositoryMojo
                 {
                     getLog().error( ex );
                 }
-            }
+            }*/
         }
 
         //process collected non-recognized external jars..
@@ -933,14 +934,14 @@ public class PopulateRepositoryMojo
             }
             String sha = encode( shaDig.digest() );
             TermQuery q = new TermQuery( new Term( "1", sha ) );
-            TopScoreDocCollector collector = TopScoreDocCollector.create(5, true);
+            TopScoreDocCollector collector = TopScoreDocCollector.create( 5 );
             searcher.search(q, collector);
             ScoreDoc[] hits = collector.topDocs().scoreDocs;
             if ( hits.length >= 1 )
             {
                 int docId = hits[0].doc;    
                 Document doc = searcher.doc(docId);                
-                Fieldable idField = doc.getFieldable( "u" );
+                IndexableField idField = doc.getField( "u" );
                 if ( idField != null )
                 {
                     String id = idField.stringValue();


### PR DESCRIPTION
Hi, this PR is to try to make nb-repository compatible with 3.5.0 maven

due to https://issues.apache.org/jira/browse/MINDEXER-106, I try to upgrade indexer to 6.0-SNAPSHOT to experiment
It require java7 compatibility upgrade to 5.5.4 lucene and a few changes in populatemojo.
Doing this changes make the plugin non compatible with 3.0.5 maven version. 

Assuming indexer 6.0 is out:
Do we still need to stick with the old maven ? Should we make 2 branches ?

Regards